### PR TITLE
Add version 1.1.x to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PatternTap.Mixfile do
   def project do
     [app: :pattern_tap,
      version: "0.2.1",
-     elixir: "~> 1.0",
+     elixir: "~> 1.0 or ~> 1.1.0",
      description: """
      Macro for tapping into a pattern match while using the pipe operator
      """,


### PR DESCRIPTION
I have tested on 1.1.1 and all the tests still passes.
